### PR TITLE
Correcting ALLOWED_FRONTEND_URLS in production settings to accept both of our frontend requests

### DIFF
--- a/backend/backend/settings/production.py
+++ b/backend/backend/settings/production.py
@@ -32,9 +32,7 @@ STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 # Frontend URLs : should be set to the actual frontend URLs in production
 # ==============================================================================
 
-ALLOWED_FRONTEND_URLS = [
-    "http://localhost:5173",  # Vite dev server
-]
+ALLOWED_FRONTEND_URLS = os.getenv("ALLOWED_FRONTEND_URLS", "").split(",")
 
 SESSION_COOKIE_SAMESITE = "None"
 CSRF_COOKIE_SAMESITE = "None"


### PR DESCRIPTION
<img width="892" height="131" alt="image" src="https://github.com/user-attachments/assets/741cf52a-af9a-4bed-9646-f5f5b092745a" />

The frontend should send its own URL in the reset password request:
{
  "email": "user@email.com",
  "frontend_url": "https://my-frontend.com"
}

So then if the user is in your frontend, the backend sends a link via email. And now, our backend accepts more then one frontend URL.